### PR TITLE
fix: remove unused fields from schema

### DIFF
--- a/final/schema.graphql
+++ b/final/schema.graphql
@@ -64,8 +64,6 @@ extend type Guest implements User @key(fields: "id") {
   name: String! @external
   "The user's profile photo URL"
   profilePicture: String! @external
-  "The reservations guest has"
-  bookings: [Booking]!
   "Amount of money in the guest's wallet"
   funds: Float!
 }

--- a/final/subgraph-listings/schema.graphql
+++ b/final/subgraph-listings/schema.graphql
@@ -147,6 +147,4 @@ type UpdateListingResponse implements MutationResponse {
 
 extend type Host @key(fields: "id") {
   id: ID! @external
-  "The listings this host owns"
-  listings: [Listing]
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -90,8 +90,6 @@ type Host implements User {
   profilePicture: String!
   "The host's profile bio description, will be shown in the listing"
   profileDescription: String!
-  "The listings this host owns"
-  listings: [Listing]
   "The overall calculated rating for the host"
   overallRating: Float
 }
@@ -105,8 +103,6 @@ type Guest implements User {
   name: String!
   "The user's profile photo URL"
   profilePicture: String!
-  "The reservations guest has"
-  bookings: [Booking]!
   "Amount of money in the guest's wallet"
   funds: Float!
 }


### PR DESCRIPTION
Removes the following fields from the schema:

- `Host.listings`
- `Guest.bookings` 

These fields shouldn't be reachable, client won't be using these. Instead, the same data is reachable through the root queries `hostListings`, `upcomingGuestBookings` and `pastGuestBookings`. 

In addition, the `Host.listings` and `Guest.bookings` fields weren't properly working anyway, they didn't have accompanying resolvers 😓 