### PR TITLE
Extend Listings Service to use Amenity transformation on Get

### DIFF
--- a/final/services/listings/index.js
+++ b/final/services/listings/index.js
@@ -61,9 +61,9 @@ app.get('/user/:userId/listings', async (req, res) => {
     where: { hostId: req.params.userId },
     include: listingsDb.Amenity,
   });
-  const listingToReturn = transformListingWithAmenities(listingInstance);
+  const listingsToReturn = listings.map((listing) => transformListingWithAmenities(listingInstance));
 
-  return res.json(listingToReturn);
+  return res.json(listingsToReturn);
 });
 
 // get listing info for a specific listing

--- a/final/services/listings/index.js
+++ b/final/services/listings/index.js
@@ -34,9 +34,11 @@ app.get('/listings', async (req, res) => {
     order: [sortOrder],
     limit: parseInt(limit, 10),
     offset: skipValue,
+    include: listingsDb.Amenity,
   });
+  const listingsToReturn = listings.map((listing) => transformListingWithAmenities(listing));
 
-  return res.json(listings);
+  return res.json(listingsToReturn);
 });
 
 // get 3 featured listings
@@ -47,14 +49,21 @@ app.get('/featured-listings', async (req, res) => {
       isFeatured: true,
     },
     limit,
+    include: listingsDb.Amenity,
   });
+  const listingsToReturn = listings.map((listing) => transformListingWithAmenities(listing));
 
-  return res.json(listings);
+  return res.json(listingsToReturn);
 });
 // get all listings for a specific user
 app.get('/user/:userId/listings', async (req, res) => {
-  const listings = await listingsDb.Listing.findAll({ where: { hostId: req.params.userId } });
-  return res.json(listings);
+  const listings = await listingsDb.Listing.findAll({ 
+    where: { hostId: req.params.userId },
+    include: listingsDb.Amenity,
+  });
+  const listingToReturn = transformListingWithAmenities(listingInstance);
+
+  return res.json(listingToReturn);
 });
 
 // get listing info for a specific listing

--- a/final/services/listings/index.js
+++ b/final/services/listings/index.js
@@ -61,7 +61,7 @@ app.get('/user/:userId/listings', async (req, res) => {
     where: { hostId: req.params.userId },
     include: listingsDb.Amenity,
   });
-  const listingsToReturn = listings.map((listing) => transformListingWithAmenities(listingInstance));
+  const listingsToReturn = listings.map((listing) => transformListingWithAmenities(listing));
 
   return res.json(listingsToReturn);
 });

--- a/services/listings/index.js
+++ b/services/listings/index.js
@@ -61,9 +61,9 @@ app.get('/user/:userId/listings', async (req, res) => {
     where: { hostId: req.params.userId },
     include: listingsDb.Amenity,
   });
-  const listingToReturn = transformListingWithAmenities(listingInstance);
+  const listingsToReturn = listings.map((listing) => transformListingWithAmenities(listingInstance));
 
-  return res.json(listingToReturn);
+  return res.json(listingsToReturn);
 });
 
 // get listing info for a specific listing

--- a/services/listings/index.js
+++ b/services/listings/index.js
@@ -34,9 +34,11 @@ app.get('/listings', async (req, res) => {
     order: [sortOrder],
     limit: parseInt(limit, 10),
     offset: skipValue,
+    include: listingsDb.Amenity,
   });
+  const listingsToReturn = listings.map((listing) => transformListingWithAmenities(listing));
 
-  return res.json(listings);
+  return res.json(listingsToReturn);
 });
 
 // get 3 featured listings
@@ -47,14 +49,21 @@ app.get('/featured-listings', async (req, res) => {
       isFeatured: true,
     },
     limit,
+    include: listingsDb.Amenity,
   });
+  const listingsToReturn = listings.map((listing) => transformListingWithAmenities(listing));
 
-  return res.json(listings);
+  return res.json(listingsToReturn);
 });
 // get all listings for a specific user
 app.get('/user/:userId/listings', async (req, res) => {
-  const listings = await listingsDb.Listing.findAll({ where: { hostId: req.params.userId } });
-  return res.json(listings);
+  const listings = await listingsDb.Listing.findAll({ 
+    where: { hostId: req.params.userId },
+    include: listingsDb.Amenity,
+  });
+  const listingToReturn = transformListingWithAmenities(listingInstance);
+
+  return res.json(listingToReturn);
 });
 
 // get listing info for a specific listing

--- a/services/listings/index.js
+++ b/services/listings/index.js
@@ -61,7 +61,7 @@ app.get('/user/:userId/listings', async (req, res) => {
     where: { hostId: req.params.userId },
     include: listingsDb.Amenity,
   });
-  const listingsToReturn = listings.map((listing) => transformListingWithAmenities(listingInstance));
+  const listingsToReturn = listings.map((listing) => transformListingWithAmenities(listing));
 
   return res.json(listingsToReturn);
 });


### PR DESCRIPTION
Currently the Listings Service does not apply the Amenity transformation on all of its Get functions. This leads to errors when querrying for Amenities on a Listing.

Example query: 
```
query FeaturedListings {
  featuredListings {
    id
    amenities {
      id
    }
  }
}
```

I have adjusted the '/listings', '/featured-listings', and '/user/:userId/listings' endpoints in the style of the '/listings/:listingId' enpoint for the Listings Service in the main project as well as in the final folder.

As this is my first PR, please let me know if I have missed anything 😃 